### PR TITLE
Fix RuntimeExpection caused by autoload classmap "database"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,6 @@
         "symfony/dom-crawler": "3.1.*"
     },
     "autoload": {
-        "classmap": [
-            "database"
-        ],
         "psr-4": {
             "Confee\\": "app/"
         }


### PR DESCRIPTION
Fix the RuntimeException below:
[RuntimeException] Could not scan for classes inside "database" which does not appear to be a file nor a folder
